### PR TITLE
Protect Player level up and stat lookups

### DIFF
--- a/Assets/Scripts/Characters/Player.cs
+++ b/Assets/Scripts/Characters/Player.cs
@@ -170,34 +170,82 @@ public class Player : Character, ISpShowable
     protected override void Awake()
     {
         base.Awake();
-        MaxHp = HpList[Level];
-        MaxSp = SpList[Level];
+        if (HpList.TryGetValue(Level, out int maxHp))
+        {
+            MaxHp = maxHp;
+        }
+        if (SpList.TryGetValue(Level, out int maxSp))
+        {
+            MaxSp = maxSp;
+        }
         Hp = MaxHp;
         Sp = MaxSp;
-        Atk = AtkList[Level];
-        Mag = MagList[Level];
-        Def = DefList[Level];
-        Res = ResList[Level];
-        Agi = AgiList[Level];
-        Luk = LukList[Level];
+        if (AtkList.TryGetValue(Level, out int atk))
+        {
+            Atk = atk;
+        }
+        if (MagList.TryGetValue(Level, out int mag))
+        {
+            Mag = mag;
+        }
+        if (DefList.TryGetValue(Level, out int def))
+        {
+            Def = def;
+        }
+        if (ResList.TryGetValue(Level, out int res))
+        {
+            Res = res;
+        }
+        if (AgiList.TryGetValue(Level, out int agi))
+        {
+            Agi = agi;
+        }
+        if (LukList.TryGetValue(Level, out int luk))
+        {
+            Luk = luk;
+        }
         ShowPortrait();
     }
 
     private void LevelUp()
     {
-        while (Exp >= ExpList[Level - 1])
+        while (Level < ExpList.Length && Exp >= ExpList[Level - 1])
         {
             Level++;
         }
 
-        MaxHp = HpList[Level];
-        MaxSp = SpList[Level];
-        Atk = AtkList[Level];
-        Mag = MagList[Level];
-        Def = DefList[Level];
-        Res = ResList[Level];
-        Agi = AgiList[Level];
-        Luk = LukList[Level];
+        if (HpList.TryGetValue(Level, out int hp))
+        {
+            MaxHp = hp;
+        }
+        if (SpList.TryGetValue(Level, out int sp))
+        {
+            MaxSp = sp;
+        }
+        if (AtkList.TryGetValue(Level, out int a))
+        {
+            Atk = a;
+        }
+        if (MagList.TryGetValue(Level, out int m))
+        {
+            Mag = m;
+        }
+        if (DefList.TryGetValue(Level, out int d))
+        {
+            Def = d;
+        }
+        if (ResList.TryGetValue(Level, out int r))
+        {
+            Res = r;
+        }
+        if (AgiList.TryGetValue(Level, out int ag))
+        {
+            Agi = ag;
+        }
+        if (LukList.TryGetValue(Level, out int l))
+        {
+            Luk = l;
+        }
 
         Hp = MaxHp;
         Sp = MaxSp;


### PR DESCRIPTION
## Summary
- guard level up to stop at max level
- check dictionary stat tables before using them

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685017e1b7b0832b93bf84fcbe412d0c