### PR TITLE
Fix component reload for prefab manager

### DIFF
--- a/Assets/Scripts/Prefab/PrefabManager.cs
+++ b/Assets/Scripts/Prefab/PrefabManager.cs
@@ -27,6 +27,7 @@ public abstract class PrefabManager<T>
     {
         Addressables.ReleaseInstance(_prefab);
         _prefab = null;
+        _component = null;
     }
 
     public TComponent GetComponentFromPrefab<TComponent>() where TComponent : Component


### PR DESCRIPTION
## Summary
- reset cached component when destroying prefab

## Testing
- `find . -name "*Test*" -type f | head`

------
https://chatgpt.com/codex/tasks/task_e_685017f77dc0832ba0c51890e0611ddb